### PR TITLE
Add follow flag to client

### DIFF
--- a/samples/family/docker-compose.yml
+++ b/samples/family/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - -c
       - |
         sleep 1
-        ./build/src/Wink start -a 10.0.0.4:42001 family/Parent 10.0.0.2:64001
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true family/Parent 10.0.0.2:64001
     expose:
       - "42001:42001/udp"
     networks:

--- a/samples/network/docker-compose.yml
+++ b/samples/network/docker-compose.yml
@@ -24,9 +24,9 @@ services:
       - -c
       - |
         sleep 1
-        ./build/src/Wink start -a 10.0.0.4:42001 useless/Useless 10.0.0.2:64000
-        ./build/src/Wink start -a client:42001 useless/Useless server:64001
-        ./build/src/Wink start -a client:42001 useless/Useless network-server-1:64002
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true useless/Useless 10.0.0.2:64000
+        ./build/src/Wink start -a client:42001 -f true useless/Useless server:64001
+        ./build/src/Wink start -a client:42001 -f true useless/Useless network-server-1:64002
     expose:
       - "42001:42001/udp"
     networks:

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -15,7 +15,10 @@ void help(std::string name, std::string command) {
   if (command == "start") {
     info() << "Start a new machine.\n\n";
     info() << "Options;";
-    // info() << "\n\t--test\n\t\tTest (default 5)\n";
+    info() << "\n\t-a\n\t\tThe address to bind to (default " << LOCALHOST
+           << ")\n";
+    info()
+        << "\n\t-f\n\t\tFollow the lifcycle of the machine (default false)\n";
     info() << "Parameters;";
     info() << "\n\tbinary\n\t\tThe machine binary to start\n";
     info() << "\n\thost\n\t\tThe host to start the machine on\n";
@@ -94,12 +97,16 @@ int main(int argc, char **argv) {
 
   if (command == "start") {
     Address address(LOCALHOST, 0);
+    bool follow = false;
 
     // Parse Options
     for (const auto &[k, v] : options) {
       if (k == "-a") {
         std::stringstream ss(v);
         ss >> address;
+      } else if (k == "-f") {
+        std::stringstream ss(v);
+        ss >> follow;
       } else {
         error() << "Option " << k << ":" << v << " not supported\n"
                 << std::flush;
@@ -129,7 +136,7 @@ int main(int argc, char **argv) {
 
     UDPSocket socket;
     if (const auto result =
-            StartMachine(socket, address, binary, destination, args, true);
+            StartMachine(socket, address, binary, destination, args, follow);
         result < 0) {
       return result;
     }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -18,7 +18,7 @@ void help(std::string name, std::string command) {
     info() << "\n\t-a\n\t\tThe address to bind to (default " << LOCALHOST
            << ")\n";
     info()
-        << "\n\t-f\n\t\tFollow the lifcycle of the machine (default false)\n";
+        << "\n\t-f\n\t\tFollow the lifecycle of the machine (default false)\n";
     info() << "Parameters;";
     info() << "\n\tbinary\n\t\tThe machine binary to start\n";
     info() << "\n\thost\n\t\tThe host to start the machine on\n";


### PR DESCRIPTION
The `-f` flag determines whether the client should follow the lifecycle of a spawned machine.