### PR TITLE
Remove unrecognized port error

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -199,8 +199,6 @@ int Server::Stop(int port) {
     // remove port from machines and pids maps
     machines.erase(port);
     pids.erase(port);
-  } else {
-    error() << "Unrecognized port " << port << '\n' << std::flush;
   }
-  return 0;
+  return pid;
 }


### PR DESCRIPTION
Unrecognized port error was showing whenever a machine was start when the server tries to kill any previous machine bound to the requested port.