### PR TITLE
Fix parsing of boolean follow flag

### DIFF
--- a/include/Wink/constants.h
+++ b/include/Wink/constants.h
@@ -1,6 +1,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+typedef unsigned char uchar;
 typedef unsigned int uint;
 typedef unsigned short ushort;
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -106,7 +106,10 @@ int main(int argc, char **argv) {
         ss >> address;
       } else if (k == "-f") {
         std::stringstream ss(v);
-        ss >> follow;
+        std::string f;
+        ss >> f;
+        std::transform(f.begin(), f.end(), f.begin(),[](uchar c){ return std::tolower(c); });
+        follow = (f == "1" || f == "true");
       } else {
         error() << "Option " << k << ":" << v << " not supported\n"
                 << std::flush;


### PR DESCRIPTION
Instead of reading the flag into the boolean, read the flag as a string, then convert it to lowercase and compare; if value is 1 or true then follow flag will be true.