### PR TITLE
Split README into subdirectories

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -10,179 +10,34 @@ A State Machine for controlling an LED with a Raspberry Pi.
 
 A State Machine that replies to every message with an identical message.
 
-### Usage
-
-```
-start echo/Echo
-send <echo> test
-```
-
 ## Family
 
 Demonstrates how a parent State Machine can spawn and monitor a child State Machine.
-
-### Usage
-
-```
-start parent/Parent
-```
 
 ## FizzBuzz
 
 A State Machine that accepts a number and prints 'fizz' if the number is divisible by 3, 'buzz' if the number is divisible by 5, and 'fizzbuzz' if the number is divisible by 3 and 5.
 
-### Usage
-
-```
-start fizzbuzz/FizzBuzz
-send <fizzbuzz> 1
-send <fizzbuzz> 2
-send <fizzbuzz> 3
-```
-
 ## Forward
 
 A State Machine that sends all received messages to another State Machine.
-
-### Usage
-
-```
-start forward/Forward <destination>
-```
 
 ## Hierarchy
 
 Demonstrates different tree shapes of Hierarchical State Machines;
 
-### Empty
-
-A tree with no nodes.
-
-### Leaf
-
-A tree with a single leaf node.
-
-```
-  Leaf
-```
-
-### Simple
-
-A tree with a parent and two child leaf nodes.
-
-```
-     Parent
-     /    \
-    /      \
-  Leaf1   Leaf2
-```
-
-### Bigger
-
-A tree with three levels of nodes.
-
-```
-     Parent
-     /    \
-    /      \
-  Leaf1    Child1
-           /   \
-          /     \
-        Leaf2  Leaf3
-```
-
-### Forrest
-
-A set of multiple trees ranging in size and shape.
-
-```
-     Parent1            Leaf1            Parent2                 Parent3
-     /    \                              /    \                     |
-    /      \                            /      \                    |
-  Leaf2    Child2                    Child3    Child4             Leaf3
-           /   \                      /          \
-          /     \                    /            \
-       Leaf4   Leaf5              Leaf6         Leaf7
-```
-
 ## Network
 
 Demonstrates how State Machines running in isolated Docker containers can communicate across a Docker network.
-
-```
-docker compose up
-```
 
 ## Switch
 
 A simple on/off toggle switch.
 
-### Usage
-
-```
-start switch/Switch
-send <switch> on
-send <switch> off
-```
-
 ## Time
 
 Demonstrates various time-related use cases.
 
-### After
-
-Send a message after a given delay.
-
-#### Usage
-
-```
-start time/After
-```
-
-### At
-
-Send a message at a specific time.
-
-#### Usage
-
-```
-start time/At
-```
-
-### StopWatch
-
-Implements a StopWatch for calculating how much time has elapsed between the watch being started and stopped.
-
-This state machine has two states; `idle` and `timing`.
-
-When the machine is in state `idle` and receives;
-
-- idle - the machine transitions back to idle.
-- start - the machine records the current time and transitions to timing.
-- stop - the machine transitions back to idle.
-- exit - the machine exits.
-
-When the machine is in state `timing` and receives;
-
-- stop - the machine records the current time, send the elapsed time to the sender, and transitions back to `idle`.
-
-The state `idle` is the parent of timing, so when timing receives an `idle`, `start`, or `exit` message, it is handled by the parent state.
-
-#### Usage
-
-```
-start time/StopWatch
-send <stopwatch> start
-send <stopwatch> stop
-
-```
-
 ## Useless
 
 A Useless State Machine that exits as soon as it is started.
-
-### Usage
-
-```
-start useless/Useless
-```

--- a/samples/echo/README.md
+++ b/samples/echo/README.md
@@ -1,0 +1,10 @@
+# Echo
+
+A State Machine that replies to every message with an identical message.
+
+## Usage
+
+```
+start echo/Echo
+send <echo> test
+```

--- a/samples/family/README.md
+++ b/samples/family/README.md
@@ -1,0 +1,9 @@
+# Family
+
+Demonstrates how a parent State Machine can spawn and monitor a child State Machine.
+
+## Usage
+
+```
+start parent/Parent
+```

--- a/samples/fizzbuzz/README.md
+++ b/samples/fizzbuzz/README.md
@@ -1,0 +1,12 @@
+# FizzBuzz
+
+A State Machine that accepts a number and prints 'fizz' if the number is divisible by 3, 'buzz' if the number is divisible by 5, and 'fizzbuzz' if the number is divisible by 3 and 5.
+
+## Usage
+
+```
+start fizzbuzz/FizzBuzz
+send <fizzbuzz> 1
+send <fizzbuzz> 2
+send <fizzbuzz> 3
+```

--- a/samples/forward/README.md
+++ b/samples/forward/README.md
@@ -1,0 +1,9 @@
+# Forward
+
+A State Machine that sends all received messages to another State Machine.
+
+## Usage
+
+```
+start forward/Forward <destination>
+```

--- a/samples/hierarchy/README.md
+++ b/samples/hierarchy/README.md
@@ -1,0 +1,54 @@
+# Hierarchy
+
+Demonstrates different tree shapes of Hierarchical State Machines;
+
+## Empty
+
+A tree with no nodes.
+
+## Leaf
+
+A tree with a single leaf node.
+
+```
+  Leaf
+```
+
+## Simple
+
+A tree with a parent and two child leaf nodes.
+
+```
+     Parent
+     /    \
+    /      \
+  Leaf1   Leaf2
+```
+
+## Bigger
+
+A tree with three levels of nodes.
+
+```
+     Parent
+     /    \
+    /      \
+  Leaf1    Child1
+           /   \
+          /     \
+        Leaf2  Leaf3
+```
+
+## Forrest
+
+A set of multiple trees ranging in size and shape.
+
+```
+     Parent1            Leaf1            Parent2                 Parent3
+     /    \                              /    \                     |
+    /      \                            /      \                    |
+  Leaf2    Child2                    Child3    Child4             Leaf3
+           /   \                      /          \
+          /     \                    /            \
+       Leaf4   Leaf5              Leaf6         Leaf7
+```

--- a/samples/network/README.md
+++ b/samples/network/README.md
@@ -1,0 +1,9 @@
+# Network
+
+Demonstrates how State Machines running in isolated Docker containers can communicate across a Docker network.
+
+## Usage
+
+```
+docker compose up
+```

--- a/samples/switch/README.md
+++ b/samples/switch/README.md
@@ -1,0 +1,11 @@
+# Switch
+
+A simple on/off toggle switch.
+
+## Usage
+
+```
+start switch/Switch
+send <switch> on
+send <switch> off
+```

--- a/samples/time/README.md
+++ b/samples/time/README.md
@@ -1,0 +1,51 @@
+# Time
+
+Demonstrates various time-related use cases.
+
+## After
+
+Send a message after a given delay.
+
+### Usage
+
+```
+start time/After
+```
+
+## At
+
+Send a message at a specific time.
+
+### Usage
+
+```
+start time/At
+```
+
+## StopWatch
+
+Implements a StopWatch for calculating how much time has elapsed between the watch being started and stopped.
+
+This state machine has two states; `idle` and `timing`.
+
+When the machine is in state `idle` and receives;
+
+- idle - the machine transitions back to idle.
+- start - the machine records the current time and transitions to timing.
+- stop - the machine transitions back to idle.
+- exit - the machine exits.
+
+When the machine is in state `timing` and receives;
+
+- stop - the machine records the current time, send the elapsed time to the sender, and transitions back to `idle`.
+
+The state `idle` is the parent of timing, so when timing receives an `idle`, `start`, or `exit` message, it is handled by the parent state.
+
+### Usage
+
+```
+start time/StopWatch
+send <stopwatch> start
+send <stopwatch> stop
+
+```

--- a/samples/useless/README.md
+++ b/samples/useless/README.md
@@ -1,0 +1,9 @@
+# Useless
+
+A Useless State Machine that exits as soon as it is started.
+
+## Usage
+
+```
+start useless/Useless
+```


### PR DESCRIPTION
By moving the details into the subdirectories the top-level README remains short and succinct.