### PR TITLE
Support optional version and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ A State Machine;
 - Writes logs to either stdout or the filesystem for Debuggability.
 - Has a Hierarchy of States to minimize Code Duplication.
 - Is Uniquely Identified by its Binary Name and Network Address;
-  - local `:<port>` or `localhost:<port>` or `127.0.0.1:<port>`
-  - remote `<ip>:<port>`
+  - binary name consists of;
+    - package and executable: `family/Parent` or `family/Child`
+    - optional [semantic versioning](https://semver.org/): `family/Parent_v0.0.1`
+    - optional tag: `family/Child:Alice` or `family/Child:Bob`
+    - compound example: `family/Child_v1.2.3:Alice`
+  - address can either be local, or remote;
+    - local: `:<port>` or `localhost:<port>` or `127.0.0.1:<port>`
+    - remote: `<ip>:<port>`
 
 ### States
 
@@ -58,15 +64,16 @@ The optional empty receiver is triggered if no other receivers match.
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "switch/Switch", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name
@@ -137,15 +144,16 @@ When a parent is notified that a child has errored, it can chose to do nothing, 
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "family/Parent", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name
@@ -212,15 +220,16 @@ int main(int argc, char **argv) {
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "family/Child", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ A State Machine;
 - Is Uniquely Identified by its Binary Name and Network Address;
   - binary name consists of;
     - package and executable: `family/Parent` or `family/Child`
-    - optional [semantic versioning](https://semver.org/): `family/Parent_v0.0.1`
+    - optional [semantic versioning](https://semver.org/): `family/Parent0.0.1`
     - optional tag: `family/Child:Alice` or `family/Child:Bob`
-    - compound example: `family/Child_v1.2.3:Alice`
+    - compound example: `family/Child1.2.3:Alice`
   - address can either be local, or remote;
     - local: `:<port>` or `localhost:<port>` or `127.0.0.1:<port>`
     - remote: `<ip>:<port>`

--- a/include/Wink/machine.h
+++ b/include/Wink/machine.h
@@ -16,15 +16,15 @@
 
 class Machine {
 public:
-  Machine(Address &spawner, Address &address, std::string name, Socket &socket)
-      : spawner(spawner), address(address), name(name), socket(socket) {}
+  Machine(std::string name, Socket &socket, Address &address, Address &spawner)
+      : name(name), socket(socket), address(address), spawner(spawner) {}
   Machine(const Machine &m) = delete;
   Machine(Machine &&m) = delete;
   ~Machine() {}
   /**
    * Returns this Machine's Unique Identifier.
    */
-  std::string Uid() const { return uid; }
+  std::string UID() const { return uid; }
   /**
    * Start begins execution of the state machine and sends a
    * 'started' message to the machine which spawned this machine.
@@ -101,12 +101,12 @@ private:
   void registerMachine(const std::string &machine, const int pid);
   void unregisterMachine();
 
-  Address &spawner;
-  Address &address;
   std::string name;
+  Socket &socket;
+  Address &address;
+  Address &spawner;
   std::string uid;
   bool running = true;
-  Socket &socket;
   Address sender;
   char buffer[MAX_PAYLOAD];
   std::map<const std::string, const std::unique_ptr<State>> states;

--- a/include/Wink/semver.h
+++ b/include/Wink/semver.h
@@ -3,6 +3,9 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
+
+#include <Wink/constants.h>
 
 class SemVer {
 public:

--- a/include/Wink/semver.h
+++ b/include/Wink/semver.h
@@ -1,0 +1,40 @@
+#ifndef SEMVER_H
+#define SEMVER_H
+
+#include <sstream>
+#include <string>
+
+class SemVer {
+public:
+  SemVer() {}
+  SemVer(std::string version) : _version(version) { stov(version); }
+  SemVer(int major, int minor, int patch, std::string prerelease,
+         std::string build)
+      : _major(major), _minor(minor), _patch(patch), _prerelease(prerelease),
+        _build(build) {
+    _version = vtos();
+  }
+  ~SemVer() {}
+  std::string version();
+  int major();
+  int minor();
+  int patch();
+  std::string prerelease();
+  std::string build();
+  void stov(const std::string &version);
+  std::string vtos() const;
+  bool operator<(const SemVer &rhs) const;
+
+private:
+  std::string _version = "";
+  int _major = 0;
+  int _minor = 0;
+  int _patch = 0;
+  std::string _prerelease = "";
+  std::string _build = "";
+};
+
+std::istream &operator>>(std::istream &is, SemVer &v);
+std::ostream &operator<<(std::ostream &os, const SemVer &v);
+
+#endif

--- a/include/Wink/server/server.h
+++ b/include/Wink/server/server.h
@@ -28,7 +28,7 @@ public:
   Server(Server &&m) = delete;
   ~Server() {}
   int Serve(const std::string &directory);
-  int Start(const std::string &binary, const std::string &machine,
+  int Start(const std::string &binary,
             const std::vector<std::string> &parameters);
   int Stop(int port);
 

--- a/include/Wink/server/server.h
+++ b/include/Wink/server/server.h
@@ -17,6 +17,7 @@
 #include <Wink/constants.h>
 #include <Wink/log.h>
 #include <Wink/machine.h>
+#include <Wink/semver.h>
 #include <Wink/socket.h>
 
 class Server {
@@ -27,7 +28,7 @@ public:
   Server(Server &&m) = delete;
   ~Server() {}
   int Serve(const std::string &directory);
-  int Start(const std::string &machine,
+  int Start(const std::string &binary, const std::string &machine,
             const std::vector<std::string> &parameters);
   int Stop(int port);
 
@@ -40,5 +41,8 @@ private:
   // Map port number to process identifier
   std::map<ushort, int> pids;
 };
+
+std::string resolveVersion(const std::string &directory,
+                           const std::string &machine);
 
 #endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -17,3 +17,5 @@ add_subdirectory("switch")
 add_subdirectory("time")
 
 add_subdirectory("useless")
+
+add_subdirectory("version")

--- a/samples/README.md
+++ b/samples/README.md
@@ -41,3 +41,7 @@ Demonstrates various time-related use cases.
 ## [Useless](useless/README.md)
 
 A Useless State Machine that exits as soon as it is started.
+
+## [Version](version/README.md)
+
+Demonstrates how multiple versions of the same State Machine can coexist.

--- a/samples/family/README.md
+++ b/samples/family/README.md
@@ -1,6 +1,6 @@
 # Family
 
-Demonstrates how a parent State Machine can spawn and monitor a child State Machine.
+This sample demonstrates how a parent State Machine can spawn child State Machine, monitor its Lifecycle, and automatically restart the child if it exits.
 
 ## Usage
 

--- a/samples/family/child.cpp
+++ b/samples/family/child.cpp
@@ -9,15 +9,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "family/Child", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/family/child.cpp
+++ b/samples/family/child.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -26,11 +27,17 @@ int main(int argc, char **argv) {
       // Parent State
       "",
       // On Entry Action
-      [&]() { m.Error("AHHHHH"); },
+      [&]() {
+        // Schedule message to be sent to self after 10s
+        m.SendAfter(address, "error", std::chrono::seconds(10));
+      },
       // On Exit Action
       []() {},
       // Receivers
-      std::map<const std::string, Receiver>{}));
+      std::map<const std::string, Receiver>{
+          {"error", [&](const Address &sender,
+                        std::istream &args) { m.Error("AHHHHH"); }},
+      }));
 
   m.Start();
 }

--- a/samples/family/parent.cpp
+++ b/samples/family/parent.cpp
@@ -27,6 +27,7 @@ int main(int argc, char **argv) {
       // On Entry Action
       [&]() {
         info() << "Parent: OnEntry\n" << std::flush;
+        // Spawn two identical children, differentiated by a tag
         m.Spawn("family/Child:Alice");
         m.Spawn("family/Child:Bob");
       },

--- a/samples/family/parent.cpp
+++ b/samples/family/parent.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "family/Parent", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name
@@ -26,7 +27,8 @@ int main(int argc, char **argv) {
       // On Entry Action
       [&]() {
         info() << "Parent: OnEntry\n" << std::flush;
-        m.Spawn("family/Child");
+        m.Spawn("family/Child:Alice");
+        m.Spawn("family/Child:Bob");
       },
       // On Exit Action
       []() { info() << "Parent: OnExit\n"
@@ -63,7 +65,7 @@ int main(int argc, char **argv) {
              args >> child;
              info() << "Parent: " << sender << ' ' << child << " has exited\n"
                     << std::flush;
-             m.GotoState("main"); // Retry
+             m.Spawn(child); // Retry
            }},
       }));
 

--- a/samples/fizzbuzz/README.md
+++ b/samples/fizzbuzz/README.md
@@ -9,4 +9,5 @@ start fizzbuzz/FizzBuzz
 send <fizzbuzz> 1
 send <fizzbuzz> 2
 send <fizzbuzz> 3
+...
 ```

--- a/samples/fizzbuzz/fizzbuzz.cpp
+++ b/samples/fizzbuzz/fizzbuzz.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "fizzbuzz/FizzBuzz", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/forward/forward.cpp
+++ b/samples/forward/forward.cpp
@@ -9,16 +9,16 @@
 int main(int argc, char **argv) {
   if (argc < 4) {
     error()
-        << "Incorrect parameters, expected <spawner> <address> <destination>\n"
+        << "Incorrect parameters, expected <address> <spawner> <destination>\n"
         << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
-  std::string name("forward/Forward");
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, name, socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   Address destination(argv[3]);
 

--- a/samples/hierarchy/bigger.cpp
+++ b/samples/hierarchy/bigger.cpp
@@ -7,15 +7,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "hierarchy/Bigger", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/hierarchy/empty.cpp
+++ b/samples/hierarchy/empty.cpp
@@ -7,15 +7,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "hierarchy/Empty", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.Start();
 }

--- a/samples/hierarchy/forrest.cpp
+++ b/samples/hierarchy/forrest.cpp
@@ -7,15 +7,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "hierarchy/Forrest", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       "Leaf1", "", []() {}, []() {},

--- a/samples/hierarchy/leaf.cpp
+++ b/samples/hierarchy/leaf.cpp
@@ -7,15 +7,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "hierarchy/Leaf", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/hierarchy/simple.cpp
+++ b/samples/hierarchy/simple.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "hierarchy/Simple", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/switch/switch.cpp
+++ b/samples/switch/switch.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "switch/Switch", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/time/after.cpp
+++ b/samples/time/after.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "time/After", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/time/at.cpp
+++ b/samples/time/at.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "time/At", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/time/stopwatch.cpp
+++ b/samples/time/stopwatch.cpp
@@ -8,15 +8,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "time/StopWatch", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   std::chrono::time_point<std::chrono::system_clock> start;
 

--- a/samples/useless/useless.cpp
+++ b/samples/useless/useless.cpp
@@ -9,15 +9,16 @@
 
 int main(int argc, char **argv) {
   if (argc < 3) {
-    error() << "Incorrect parameters, expected <spawner> <address>\n"
+    error() << "Incorrect parameters, expected <address> <spawner>\n"
             << std::flush;
     return -1;
   }
 
-  Address spawner(argv[1]);
-  Address address(argv[2]);
+  std::string name(argv[0]);
   UDPSocket socket;
-  Machine m(spawner, address, "useless/Useless", socket);
+  Address address(argv[1]);
+  Address spawner(argv[2]);
+  Machine m(name, socket, address, spawner);
 
   m.AddState(std::make_unique<State>(
       // State Name

--- a/samples/version/CMakeLists.txt
+++ b/samples/version/CMakeLists.txt
@@ -4,7 +4,7 @@ set(INCLUDE_DIR "../../include")
 
 foreach(version IN ITEMS 0.0.1 0.0.2 0.0.3)
 
-    set(TARGET_NAME Version_v${version})
+    set(TARGET_NAME Version${version})
 
     set(SOURCE
         "version.cpp"

--- a/samples/version/CMakeLists.txt
+++ b/samples/version/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LIBRARY_NAME libWink)
+
+set(INCLUDE_DIR "../../include")
+
+foreach(version IN ITEMS 0.0.1 0.0.2 0.0.3)
+
+    set(TARGET_NAME Version_v${version})
+
+    set(SOURCE
+        "version.cpp"
+    )
+
+    include_directories(${INCLUDE_DIR})
+
+    add_executable(${TARGET_NAME} ${SOURCE})
+
+    target_link_libraries(${TARGET_NAME} ${LIBRARY_NAME})
+
+endforeach()

--- a/samples/version/README.md
+++ b/samples/version/README.md
@@ -1,0 +1,9 @@
+# Useless
+
+A Useless State Machine that exits as soon as it is started.
+
+## Usage
+
+```
+start useless/Useless
+```

--- a/samples/version/README.md
+++ b/samples/version/README.md
@@ -1,9 +1,9 @@
-# Useless
+# Version
 
-A Useless State Machine that exits as soon as it is started.
+A State Machine that is compiled into multiple versions to show how they can coexist.
 
 ## Usage
 
 ```
-start useless/Useless
+docker compose up
 ```

--- a/samples/version/docker-compose.yml
+++ b/samples/version/docker-compose.yml
@@ -25,11 +25,11 @@ services:
       - |
         sleep 1
         # Start Version 0.0.1
-        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.1 10.0.0.2:64001
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version0.0.1 10.0.0.2:64001
         # Start Version 0.0.2
-        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.2 10.0.0.2:64002
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version0.0.2 10.0.0.2:64002
         # Start Version 0.0.3
-        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.3 10.0.0.2:64003
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version0.0.3 10.0.0.2:64003
         # Start Latest Version
         ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version 10.0.0.2:64000
     expose:

--- a/samples/version/docker-compose.yml
+++ b/samples/version/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  server:
+    image: wink:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        ls build/samples/
+        ./build/src/WinkServer serve -a 10.0.0.2:42000 build/samples/
+    expose:
+      - "42000:42000/udp"
+      - "64000:64000/udp"
+      - "64001:64001/udp"
+      - "64002:64002/udp"
+    networks:
+      winknet:
+        ipv4_address: 10.0.0.2
+    working_dir: /Wink
+
+  client:
+    image: wink:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        sleep 1
+        # Start Version 0.0.1
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.1 10.0.0.2:64001
+        # Start Version 0.0.2
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.2 10.0.0.2:64002
+        # Start Version 0.0.3
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version_v0.0.3 10.0.0.2:64003
+        # Start Latest Version
+        ./build/src/Wink start -a 10.0.0.4:42001 -f true version/Version 10.0.0.2:64000
+    expose:
+      - "42001:42001/udp"
+    networks:
+      winknet:
+        ipv4_address: 10.0.0.4
+    working_dir: /Wink
+
+networks:
+  winknet:
+    driver: bridge
+    internal: true
+    ipam:
+     config:
+       - subnet: 10.0.0.0/16
+         gateway: 10.0.0.1

--- a/samples/version/version.cpp
+++ b/samples/version/version.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include <Wink/address.h>
@@ -25,18 +26,14 @@ int main(int argc, char **argv) {
       // Parent State
       "",
       // On Entry Action
-      []() {},
+      [&]() {
+        info() << "UID: " << m.UID() << '\n' << std::flush;
+        m.Exit();
+      },
       // On Exit Action
       []() {},
       // Receivers
-      std::map<const std::string, Receiver>{
-          {"",
-           [&](const Address &sender, std::istream &args) {
-             std::ostringstream os;
-             os << args.rdbuf();
-             m.Send(sender, os.str());
-           }},
-      }));
+      std::map<const std::string, Receiver>{}));
 
   m.Start();
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   "client.cpp"
   "log.cpp"
   "machine.cpp"
+  "semver.cpp"
   "udp.cpp"
 )
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -58,7 +58,7 @@ int StartMachine(Socket &socket, Address &address, const std::string &binary,
   }
   std::string b;
   iss >> b;
-  if (b != binary) {
+  if (!b.starts_with(binary)) {
     error() << "Incorrect machine binary started. Expected: \"" << binary
             << "\", Got: \"" << b << "\"\n"
             << std::flush;

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -1,6 +1,11 @@
 #include <Wink/machine.h>
 
 void Machine::Start(const std::string &initial) {
+  if (states.empty()) {
+    // Nothing to do
+    return;
+  }
+
   // Bind to port
   if (const auto result = socket.Bind(address); result < 0) {
     error() << "Failed to bind to port " << address.port << '\n' << std::flush;
@@ -8,9 +13,9 @@ void Machine::Start(const std::string &initial) {
   }
 
   std::ostringstream oss;
-  oss << address;
-  oss << ' ';
   oss << name;
+  oss << '@';
+  oss << address;
   uid = oss.str();
 
   // Set Receive Timeout

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -263,6 +263,10 @@ void Machine::handleMessage(
     std::string name;
     iss >> name;
     spawned.emplace(key, std::make_pair(name, now));
+    // Put name back into the stream
+    for (int i = 0; i < name.length(); i++) {
+      iss.unget();
+    }
   } else if (m == "exited") {
     spawned.erase(key);
   } else if (m == "pulsed") {

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -263,10 +263,8 @@ void Machine::handleMessage(
     std::string name;
     iss >> name;
     spawned.emplace(key, std::make_pair(name, now));
-    // Put name back into the stream
-    for (int i = 0; i < name.length(); i++) {
-      iss.unget();
-    }
+    // Seek back to start of name to make it available to the message handler.
+    iss.seekg(-name.length(), std::ios_base::cur);
   } else if (m == "exited") {
     spawned.erase(key);
   } else if (m == "pulsed") {

--- a/src/semver.cpp
+++ b/src/semver.cpp
@@ -1,0 +1,100 @@
+#include <cctype>
+#include <cstring>
+
+#include <Wink/log.h>
+#include <Wink/semver.h>
+
+std::string SemVer::version() { return _version; }
+
+int SemVer::major() { return _major; }
+
+int SemVer::minor() { return _minor; }
+
+int SemVer::patch() { return _patch; }
+
+std::string SemVer::prerelease() { return _prerelease; }
+
+std::string SemVer::build() { return _build; }
+
+void SemVer::stov(const std::string &version) {
+  std::istringstream iss(version);
+  char c;
+  iss >> _major;
+  iss >> c;
+  iss >> _minor;
+  iss >> c;
+  iss >> _patch;
+  if (iss) {
+    std::string label;
+    iss >> label;
+    const auto p = label.find('-');
+    const auto b = label.find('+');
+    if (p != std::string::npos && b != std::string::npos) {
+      _prerelease = label.substr(p + 1, b - 1);
+      _build = label.substr(b + 1);
+    } else if (p != std::string::npos && b == std::string::npos) {
+      _prerelease = label.substr(p + 1);
+    } else if (p == std::string::npos && b != std::string::npos) {
+      _build = label.substr(b + 1);
+    }
+  }
+}
+
+std::string SemVer::vtos() const {
+  std::ostringstream oss;
+  oss << _major;
+  oss << '.';
+  oss << _minor;
+  oss << '.';
+  oss << _patch;
+  if (!_prerelease.empty()) {
+    oss << '-';
+    oss << _prerelease;
+  }
+  if (!_build.empty()) {
+    oss << "+";
+    oss << _build;
+  }
+  return oss.str();
+}
+
+std::istream &operator>>(std::istream &is, SemVer &v) {
+  std::string s;
+  is >> s;
+  v.stov(s);
+  return is;
+}
+
+std::ostream &operator<<(std::ostream &os, const SemVer &v) {
+  os << v.vtos();
+  return os;
+}
+
+bool SemVer::operator<(const SemVer &rhs) const {
+  if (_major < rhs._major) {
+    return true;
+  }
+  if (_minor < rhs._minor) {
+    return true;
+  }
+  if (_patch < rhs._patch) {
+    return true;
+  }
+  // Compare prereleases
+  if (!_prerelease.empty() && rhs._prerelease.empty()) {
+    return true;
+  } else if (_prerelease.empty() && !rhs._prerelease.empty()) {
+    return false;
+  } else if (!_prerelease.empty() && !rhs._prerelease.empty()) {
+    // TODO compare prerelease components
+  }
+  // Compare builds
+  if (!_build.empty() && rhs._build.empty()) {
+    return true;
+  } else if (_build.empty() && !rhs._build.empty()) {
+    return false;
+  } else if (!_build.empty() && !rhs._build.empty()) {
+    // TODO compare build components
+  }
+  return false;
+}

--- a/src/semver.cpp
+++ b/src/semver.cpp
@@ -70,6 +70,14 @@ std::ostream &operator<<(std::ostream &os, const SemVer &v) {
   return os;
 }
 
+void splitLabel(std::vector<std::string> &v, std::string s) {
+  std::istringstream iss(s);
+  std::string item;
+  while (std::getline(iss, item, '.')) {
+    v.push_back(item);
+  }
+}
+
 bool SemVer::operator<(const SemVer &rhs) const {
   if (_major < rhs._major) {
     return true;
@@ -86,7 +94,32 @@ bool SemVer::operator<(const SemVer &rhs) const {
   } else if (_prerelease.empty() && !rhs._prerelease.empty()) {
     return false;
   } else if (!_prerelease.empty() && !rhs._prerelease.empty()) {
-    // TODO compare prerelease components
+    std::vector<std::string> ls;
+    std::vector<std::string> rs;
+    splitLabel(ls, _prerelease);
+    splitLabel(rs, rhs._prerelease);
+    for (uint i = 0;; i++) {
+      if (i < ls.size() && i < rs.size()) {
+        if (ls[i] == rs[i]) {
+          continue;
+        }
+        const auto ld = std::isdigit(ls[i][0]);
+        const auto rd = std::isdigit(rs[i][0]);
+        if (ld && rd) {
+          // Compare numerically
+          return std::stoi(ls[i]) < std::stoi(rs[i]);
+        } else if (!ld && !rd) {
+          // Compare alphabetically
+          return ls[i] < rs[i];
+        } else {
+          return ld;
+        }
+      } else if (i >= ls.size() && i >= rs.size()) {
+        break;
+      } else {
+        return i < rs.size();
+      }
+    }
   }
   // Compare builds
   if (!_build.empty() && rhs._build.empty()) {
@@ -94,7 +127,32 @@ bool SemVer::operator<(const SemVer &rhs) const {
   } else if (_build.empty() && !rhs._build.empty()) {
     return false;
   } else if (!_build.empty() && !rhs._build.empty()) {
-    // TODO compare build components
+    std::vector<std::string> ls;
+    std::vector<std::string> rs;
+    splitLabel(ls, _build);
+    splitLabel(rs, rhs._build);
+    for (uint i = 0;; i++) {
+      if (i < ls.size() && i < rs.size()) {
+        if (ls[i] == rs[i]) {
+          continue;
+        }
+        const auto ld = std::isdigit(ls[i][0]);
+        const auto rd = std::isdigit(rs[i][0]);
+        if (ld && rd) {
+          // Compare numerically
+          return std::stoi(ls[i]) < std::stoi(rs[i]);
+        } else if (!ld && !rd) {
+          // Compare alphabetically
+          return ls[i] < rs[i];
+        } else {
+          return ld;
+        }
+      } else if (i >= ls.size() && i >= rs.size()) {
+        break;
+      } else {
+        return i < rs.size();
+      }
+    }
   }
   return false;
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -69,11 +69,11 @@ int Server::Serve(const std::string &directory) {
       }
 
       // Resolve correct version (if any).
-      // ie. <name> or <name>_v<version>.
+      // ie. <name> or <name><version>.
       name = resolveVersion(directory, name);
 
       // Resolve binary file.
-      // ie. <directory>/<name> or <directory>/<name>_v<version>.
+      // ie. <directory>/<name> or <directory>/<name><version>.
       std::filesystem::path binary(directory);
       binary /= name;
 
@@ -82,8 +82,8 @@ int Server::Serve(const std::string &directory) {
 
       // First parameter is name of the machine, optionally including version
       // and tag. This will also become the log file name (if enabled).
-      // ie. <name>, <name>_v<version>, <name>:<tag>, or
-      // <name>_v<version>:<tag>.
+      // ie. <name>, <name><version>, <name>:<tag>, or
+      // <name><version>:<tag>.
       parameters.push_back(name + tag);
 
       // Second parameter is the address of the machine.
@@ -229,8 +229,8 @@ std::string resolveVersion(const std::string &directory,
   binary /= machine;
 
   if (!std::filesystem::exists(binary)) {
-    // Check if <binary>_v<semver> exists, if so use latest version
-    const auto bin = binary.string() + "_v";
+    // Check if <binary><semver> exists, if so use latest version
+    const auto bin = binary.string();
     const auto len = bin.length();
     std::vector<SemVer> versions;
     const auto directory = binary.parent_path();
@@ -247,7 +247,6 @@ std::string resolveVersion(const std::string &directory,
 
       std::ostringstream ms;
       ms << machine;
-      ms << "_v";
       // Last element in sorted vector is latest version
       ms << versions.back();
       return ms.str();

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -64,8 +64,8 @@ int Server::Serve(const std::string &directory) {
       std::string name = machine;
       std::string tag = "";
       if (const auto i = machine.find(':'); i != std::string::npos) {
-        name = machine.substr(0, i - 1);
-        tag = machine.substr(i + 1);
+        name = machine.substr(0, i);
+        tag = machine.substr(i);
       }
 
       // Resolve correct version if any (ie. <name> or <name>_v<version>)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE
   "address.cpp"
   "client.cpp"
   "machine.cpp"
+  "semver.cpp"
   "server.cpp"
   "socket.cpp"
   "udp.cpp"

--- a/test/src/machine.cpp
+++ b/test/src/machine.cpp
@@ -7,11 +7,17 @@
 #include <WinkTest/constants.h>
 #include <WinkTest/socket.h>
 
+TEST(MachineTest, UID) {
+  // TODO Basic
+  // TODO Tag
+  // TODO Version
+}
+
 TEST(MachineTest, Start) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
   // Set mock bind result
   {
     BindResult result;
@@ -49,7 +55,7 @@ TEST(MachineTest, Start) {
   int mainOnEntry;
   int mainOnExit;
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.AddState(std::make_unique<State>(
@@ -68,7 +74,7 @@ TEST(MachineTest, Start) {
       std::map<const std::string, Receiver>{}));
   m.Start();
 
-  ASSERT_EQ("127.0.0.1:42002 test/Test", m.Uid());
+  ASSERT_EQ("test/Test@127.0.0.1:42002", m.UID());
 
   // Bind call
   { ASSERT_EQ(1, socket.bindArgs.size()); }
@@ -122,10 +128,10 @@ TEST(MachineTest, Start) {
 }
 
 TEST(MachineTest, Start_InitialState) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
   // Set mock bind result
   {
     BindResult result;
@@ -165,7 +171,7 @@ TEST(MachineTest, Start_InitialState) {
   int secondOnEntry;
   int secondOnExit;
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.AddState(std::make_unique<State>(
@@ -206,7 +212,7 @@ TEST(MachineTest, Start_InitialState) {
       std::map<const std::string, Receiver>{}));
   m.Start("second");
 
-  ASSERT_EQ("127.0.0.1:42002 test/Test", m.Uid());
+  ASSERT_EQ("test/Test@127.0.0.1:42002", m.UID());
 
   // Bind call
   { ASSERT_EQ(1, socket.bindArgs.size()); }
@@ -269,17 +275,17 @@ TEST(MachineTest, Start_Heartbeat) {
 }
 
 TEST(MachineTest, Exit) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
   socket.sendResults.push_back(result);
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.Exit();
@@ -301,10 +307,10 @@ TEST(MachineTest, Exit) {
 }
 
 TEST(MachineTest, Error) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
@@ -312,7 +318,7 @@ TEST(MachineTest, Error) {
   socket.sendResults.push_back(result);
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.Error("AHHHH");
@@ -340,26 +346,27 @@ TEST(MachineTest, Error) {
 }
 
 TEST(MachineTest, AddState) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   // TODO Test state is added to the vector of states
   // TODO Test first state becomes initial default
 }
 
 TEST(MachineTest, GotoState) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
-  Machine m(spawner, address, name, socket);
+  Address address(":42002");
+  Address spawner(":42001");
+
+  Machine m(name, socket, address, spawner);
 
   int firstOnEntry = 0;
   int firstOnExit = 0;
@@ -399,16 +406,16 @@ TEST(MachineTest, GotoState) {
 }
 
 TEST(MachineTest, Send) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
 
   Address destination(":42003");
   m.Send(destination, TEST_MESSAGE);
@@ -423,11 +430,12 @@ TEST(MachineTest, Send) {
 }
 
 TEST(MachineTest, SendAt) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   UDPSocket socket;
-  Machine m(spawner, address, name, socket);
+  Address address(":42002");
+  Address spawner(":42001");
+
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.AddState(std::make_unique<State>(
@@ -454,11 +462,12 @@ TEST(MachineTest, SendAt) {
 }
 
 TEST(MachineTest, SendAfter) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   UDPSocket socket;
-  Machine m(spawner, address, name, socket);
+  Address address(":42002");
+  Address spawner(":42001");
+
+  Machine m(name, socket, address, spawner);
   // Override exit
   m.onExit = []() {};
   m.AddState(std::make_unique<State>(
@@ -483,16 +492,16 @@ TEST(MachineTest, SendAfter) {
 }
 
 TEST(MachineTest, Spawn_Local) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   m.Spawn("useless/Useless");
 
   // Check socket send
@@ -505,16 +514,16 @@ TEST(MachineTest, Spawn_Local) {
 }
 
 TEST(MachineTest, Spawn_Remote) {
-  Address spawner(":42001");
-  Address address(":42002");
   std::string name("test/Test");
   MockSocket socket;
+  Address address(":42002");
+  Address spawner(":42001");
 
   // Set mock send result
   SendResult result = 0;
   socket.sendResults.push_back(result);
 
-  Machine m(spawner, address, name, socket);
+  Machine m(name, socket, address, spawner);
   Address destination(TEST_IP, TEST_PORT);
   m.Spawn("useless/Useless", destination);
 

--- a/test/src/semver.cpp
+++ b/test/src/semver.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <Wink/semver.h>
+
+TEST(SemVerTest, Core) {
+  SemVer s1(1, 2, 3, "", "");
+  ASSERT_EQ(1, s1.major());
+  ASSERT_EQ(2, s1.minor());
+  ASSERT_EQ(3, s1.patch());
+
+  SemVer s2("1.2.3");
+  ASSERT_EQ(1, s2.major());
+  ASSERT_EQ(2, s2.minor());
+  ASSERT_EQ(3, s2.patch());
+}
+
+TEST(SemVerTest, CorePrerelease) {
+  SemVer s1(1, 2, 3, "alpha", "");
+  ASSERT_EQ(1, s1.major());
+  ASSERT_EQ(2, s1.minor());
+  ASSERT_EQ(3, s1.patch());
+  ASSERT_EQ("alpha", s1.prerelease());
+
+  SemVer s2("1.2.3-alpha");
+  ASSERT_EQ(1, s2.major());
+  ASSERT_EQ(2, s2.minor());
+  ASSERT_EQ(3, s2.patch());
+  ASSERT_EQ("alpha", s2.prerelease());
+}
+
+TEST(SemVerTest, CoreBuild) {
+  SemVer s1(1, 2, 3, "", "20230111");
+  ASSERT_EQ(1, s1.major());
+  ASSERT_EQ(2, s1.minor());
+  ASSERT_EQ(3, s1.patch());
+  ASSERT_EQ("20230111", s1.build());
+
+  SemVer s2("1.2.3+20230111");
+  ASSERT_EQ(1, s2.major());
+  ASSERT_EQ(2, s2.minor());
+  ASSERT_EQ(3, s2.patch());
+  ASSERT_EQ("20230111", s2.build());
+}
+
+TEST(SemVerTest, CorePrereleaseBuild) {
+  SemVer s1(1, 2, 3, "alpha", "20230111");
+  ASSERT_EQ(1, s1.major());
+  ASSERT_EQ(2, s1.minor());
+  ASSERT_EQ(3, s1.patch());
+  ASSERT_EQ("alpha", s1.prerelease());
+  ASSERT_EQ("20230111", s1.build());
+
+  SemVer s2("1.2.3-alpha+20230111");
+  ASSERT_EQ(1, s2.major());
+  ASSERT_EQ(2, s2.minor());
+  ASSERT_EQ(3, s2.patch());
+  ASSERT_EQ("alpha", s2.prerelease());
+  ASSERT_EQ("20230111", s2.build());
+}
+
+TEST(SemVerTest, Stream) {
+  SemVer s1(1, 2, 3, "alpha", "20230111");
+  std::ostringstream oss;
+  oss << s1;
+
+  SemVer s2;
+  std::istringstream iss(oss.str());
+  iss >> s2;
+
+  ASSERT_EQ(1, s2.major());
+  ASSERT_EQ(2, s2.minor());
+  ASSERT_EQ(3, s2.patch());
+  ASSERT_EQ("alpha", s2.prerelease());
+  ASSERT_EQ("20230111", s2.build());
+}
+
+TEST(SemVerTest, Compare) {
+  ASSERT_TRUE(SemVer("1.0.0") < SemVer("2.0.0"));
+  ASSERT_TRUE(SemVer("1.0.0") < SemVer("1.1.0"));
+  ASSERT_TRUE(SemVer("1.0.0") < SemVer("1.0.1"));
+  ASSERT_TRUE(SemVer("1.0.0+alpha") < SemVer("1.0.0"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha") < SemVer("1.0.0+alpha.1"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha.1") < SemVer("1.0.0+alpha.beta"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha.beta") < SemVer("1.0.0+beta"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+beta") < SemVer("1.0.0+beta.2"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+beta.2") < SemVer("1.0.0+beta.11"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+beta.1") < SemVer("1.0.0+rc1"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+rc1") < SemVer("1.0.0"));
+  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha-20230111") <
+  // SemVer("1.0.0+alpha-20230112"));
+}

--- a/test/src/semver.cpp
+++ b/test/src/semver.cpp
@@ -29,37 +29,37 @@ TEST(SemVerTest, CorePrerelease) {
 }
 
 TEST(SemVerTest, CoreBuild) {
-  SemVer s1(1, 2, 3, "", "20230111");
+  SemVer s1(1, 2, 3, "", "2023.1.11");
   ASSERT_EQ(1, s1.major());
   ASSERT_EQ(2, s1.minor());
   ASSERT_EQ(3, s1.patch());
-  ASSERT_EQ("20230111", s1.build());
+  ASSERT_EQ("2023.1.11", s1.build());
 
-  SemVer s2("1.2.3+20230111");
+  SemVer s2("1.2.3+2023.1.11");
   ASSERT_EQ(1, s2.major());
   ASSERT_EQ(2, s2.minor());
   ASSERT_EQ(3, s2.patch());
-  ASSERT_EQ("20230111", s2.build());
+  ASSERT_EQ("2023.1.11", s2.build());
 }
 
 TEST(SemVerTest, CorePrereleaseBuild) {
-  SemVer s1(1, 2, 3, "alpha", "20230111");
+  SemVer s1(1, 2, 3, "alpha", "2023.1.11");
   ASSERT_EQ(1, s1.major());
   ASSERT_EQ(2, s1.minor());
   ASSERT_EQ(3, s1.patch());
   ASSERT_EQ("alpha", s1.prerelease());
-  ASSERT_EQ("20230111", s1.build());
+  ASSERT_EQ("2023.1.11", s1.build());
 
-  SemVer s2("1.2.3-alpha+20230111");
+  SemVer s2("1.2.3-alpha+2023.1.11");
   ASSERT_EQ(1, s2.major());
   ASSERT_EQ(2, s2.minor());
   ASSERT_EQ(3, s2.patch());
   ASSERT_EQ("alpha", s2.prerelease());
-  ASSERT_EQ("20230111", s2.build());
+  ASSERT_EQ("2023.1.11", s2.build());
 }
 
 TEST(SemVerTest, Stream) {
-  SemVer s1(1, 2, 3, "alpha", "20230111");
+  SemVer s1(1, 2, 3, "alpha", "2023.1.11");
   std::ostringstream oss;
   oss << s1;
 
@@ -71,21 +71,24 @@ TEST(SemVerTest, Stream) {
   ASSERT_EQ(2, s2.minor());
   ASSERT_EQ(3, s2.patch());
   ASSERT_EQ("alpha", s2.prerelease());
-  ASSERT_EQ("20230111", s2.build());
+  ASSERT_EQ("2023.1.11", s2.build());
 }
 
 TEST(SemVerTest, Compare) {
   ASSERT_TRUE(SemVer("1.0.0") < SemVer("2.0.0"));
   ASSERT_TRUE(SemVer("1.0.0") < SemVer("1.1.0"));
   ASSERT_TRUE(SemVer("1.0.0") < SemVer("1.0.1"));
-  ASSERT_TRUE(SemVer("1.0.0+alpha") < SemVer("1.0.0"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha") < SemVer("1.0.0+alpha.1"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha.1") < SemVer("1.0.0+alpha.beta"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha.beta") < SemVer("1.0.0+beta"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+beta") < SemVer("1.0.0+beta.2"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+beta.2") < SemVer("1.0.0+beta.11"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+beta.1") < SemVer("1.0.0+rc1"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+rc1") < SemVer("1.0.0"));
-  // TODO ASSERT_TRUE(SemVer("1.0.0+alpha-20230111") <
-  // SemVer("1.0.0+alpha-20230112"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha") < SemVer("1.0.0"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha") < SemVer("1.0.0-alpha.1"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha.1") < SemVer("1.0.0-alpha.beta"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha.beta") < SemVer("1.0.0-beta"));
+  ASSERT_TRUE(SemVer("1.0.0-beta") < SemVer("1.0.0-beta.2"));
+  ASSERT_TRUE(SemVer("1.0.0-beta.2") < SemVer("1.0.0-beta.11"));
+  ASSERT_TRUE(SemVer("1.0.0-beta.1") < SemVer("1.0.0-rc1"));
+  ASSERT_TRUE(SemVer("1.0.0-rc1") < SemVer("1.0.0"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha+2023.1.11") <
+              SemVer("1.0.0-alpha+2023.1.12"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha+2023.x") < SemVer("1.0.0-alpha+2023.y"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha+2023.1") < SemVer("1.0.0-alpha+2023.x"));
+  ASSERT_TRUE(SemVer("1.0.0-alpha+2023.1") < SemVer("1.0.0-alpha+2023.1.11"));
 }

--- a/test/src/server.cpp
+++ b/test/src/server.cpp
@@ -19,8 +19,8 @@ TEST(ServerTest, Start) {
   Address address(LOCALHOST, SERVER_PORT);
   UDPSocket socket;
   Server server(address, socket);
-  const std::vector<std::string> args;
-  ASSERT_EQ(0, server.Start("./samples/", "useless/Useless", args));
+  const std::vector<std::string> args{"useless/Useless"};
+  ASSERT_EQ(0, server.Start("./samples/", args));
 }
 
 TEST(ServerTest, Stop) {

--- a/test/src/server.cpp
+++ b/test/src/server.cpp
@@ -20,7 +20,7 @@ TEST(ServerTest, Start) {
   UDPSocket socket;
   Server server(address, socket);
   const std::vector<std::string> args;
-  ASSERT_EQ(0, server.Start("./samples/useless/Useless", args));
+  ASSERT_EQ(0, server.Start("./samples/", "useless/Useless", args));
 }
 
 TEST(ServerTest, Stop) {


### PR DESCRIPTION
State Machines identities can now include an optional version to enable multiple versions of the same binary and tag to distinguish multiple instances of the same binary;
- `package`/`name`@`address`
- `package`/`name`:`tag`@`address`
- `package`/`nameversion`@`address`
- `package`/`nameversion`:`tag`@`address`

Fixes: #11